### PR TITLE
Macros Support

### DIFF
--- a/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Annotations.stencil
+++ b/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Annotations.stencil
@@ -1,5 +1,5 @@
 // Template name: Annotations
-// Template version: 1.0
+// Template version: 1.1
 
 {% macro includeImports type %}
     {% for import in type.imports %}
@@ -8,46 +8,50 @@ import {{ import }}
 {% endmacro %}
 
 /*
-    Example:
-        /// @State(JournalView)
+    Examples:
+        @State(ViewType.self)
+        @State(ViewType1.self, ViewType2.self)
 */
 {% for type in types.structs %}
-  {% for comment in type.documentation %}
-    {% if comment|contains:"@State(" %}
-        {% call includeImports type %}
-        {% set state %}{{ comment | replace:"@State(","" | replace:")","" }}{% endset %}
-extension {{ state }} {
+    {% for attribute, objects in type.attributes %}
+        {% if attribute == "State" %}
+            {% set viewTypes %}{{ objects[0].description|replace:"@Event(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
+            {% for view in viewTypes|split: "," %}
+extension {{ view }} {
     typealias State = {{ type.name }}
 }
-    {% endif %}
-  {% endfor %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+/*
+    Examples:
+        @Event(ViewType.self)
+        @Event(ViewType1.self, ViewType2.self)
+*/
+{% for type in types.enums %}
+    {% for attribute, objects in type.attributes %}
+        {% if attribute == "Event" %}
+            {% set viewTypes %}{{ objects[0].description|replace:"@Event(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
+            {% for view in viewTypes|split: "," %}
+extension {{ view }} {
+    typealias Event = {{ type.name }}
+}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
 {% endfor %}
 
 /*
     Example:
-        /// @Event(JournalView)
+        @Loop(in: EventType.self, out: StateType.self)
 */
-{% for type in types.enums %}
-  {% for comment in type.documentation %}
-    {% if comment|contains:"@Event(" %}
-        {% call includeImports type %}
-        {% set event %}{{ comment | replace:"@Event(","" | replace:")","" }}{% endset %}
-extension {{ event }} {
-    typealias Event = {{ type.name }}
-}
-    {% endif %}
-  {% endfor %}
-{% endfor %}
 
 // TODO: find a better way to handle default external names
 {% macro associatedValueName value index -%}
     {%- if value.localName == nil -%}{%- if value.externalName == nil or value.externalName == "0" or value.externalName == "1" or value.externalName == "2" -%}{{ value.typeName|lowerFirstLetter|replace:".","" }}{{ index }}{%- else -%}{{ value.externalName }}{%- endif -%}{%- else -%}{{ value.localName }}{%- endif -%}
 {%- endmacro %}
-
-/*
-    Example
-    /// @Loop(StateModel, EventEnum)
-*/
 
 {% macro propertyUpdates state %}
     {% for type in types.structs where type.name == state %}
@@ -123,15 +127,23 @@ enum OptionalUpdate<T> {
 
 {% for type in types.all %}
   {% for comment in type.documentation %}
-    {% if comment|contains:"@Loop" %}
+    {% if attribute == "Loop" %}
+        {% set parameters %}{{ objects[0].description|replace:"@Loop(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
+        // TODO: get the state and event type
+        {% set event %}{{ parameters|replace:" ",""|split: ","[0] }}{% endset %}
+        {% set state %}{{ parameters|replace:" ",""|split: ","[1] }}{% endset %}
+        
 import SwiftUDF
 import SwiftEvolution
 import Combine
         {% call includeImports type %}
         
-class GeneratedBase{{ type.name }}: ViewProvider {
+class {{ type.name }}BaseGenerated: ViewProvider {
     let state: CurrentValuePublisher<State>
     private let mutableState: MutableState<State>
+    
+    typealias Event = {{ event }}
+    typealias State = {{ state }}
     
     // TODO: Default init for State thtat implements 'Initialable'
     init(initial: State) {
@@ -141,11 +153,8 @@ class GeneratedBase{{ type.name }}: ViewProvider {
     
     var subscriptions = [AnyCancellable]()
     
-        {% set typePair %}{{ comment|replace:"@Loop(",""|replace:")","" }}{% endset %}
-        
-        {% for innerType in typePair|split: "," %}
-            {% if forloop.counter == 1 %}
-                {% set state %}{{ innerType }}{% endset %}
+    // MARK: State
+    
     var currentState: State { state.value }
     
     {% call propertyUpdates state %}
@@ -162,69 +171,59 @@ class GeneratedBase{{ type.name }}: ViewProvider {
         update(mutableState)
     }
     
-    typealias State = {{ state }}
-            {% endif %}
-            
-            {% if forloop.counter == 2 %}
-                {% set event %}{{ innerType|replace:" ","" }}{% endset %}
-    typealias Event = {{ event }}
-                {% for eventEnum in types.enums where eventEnum.name == event %}
-                
-    /*
-        Events entry point
-    */
+    // MARK: Event
+    
+    {% for eventEnum in types.enums where eventEnum.name == event %}
+        {% if forloop.counter == 1 %}
     func handle(_ event: Event) {
         {{ "switch event {" if eventEnum.cases.count > 0 }}
-                    {% for case in eventEnum.cases %}
-                        {% if case.hasAssociatedValue %}
+            {% for case in eventEnum.cases %}
+                {% if case.hasAssociatedValue %}
             case .{{ case.name }}(
-                            {% for associatedValue in case.associatedValues %}
-                                {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
+                    {% for associatedValue in case.associatedValues %}
+                        {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
                 let {{ name }}{{ ", " if not forloop.last }}
-                            {% endfor %}
-                ): {{ case.name }}(
-                            {% for associatedValue in case.associatedValues %}
-                                {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
-                    {{ name }}: {{ name }}{{ ", " if not forloop.last }}
-                            {% endfor %}
-                )
-                        {% else %}
-            case .{{ case.name }}: {{ case.name }}()
-                        {% endif %}
                     {% endfor %}
+                ): {{ case.name }}(
+                    {% for associatedValue in case.associatedValues %}
+                        {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
+                    {{ name }}: {{ name }}{{ ", " if not forloop.last }}
+                    {% endfor %}
+                )
+                {% else %}
+            case .{{ case.name }}: {{ case.name }}()
+                {% endif %}
+            {% endfor %}
         {{ "}" if eventEnum.cases.count > 0 }}
     }
     
-    /*
-        Override functions
-    */
+            {% for case in eventEnum.cases %}
+                {% if case.hasAssociatedValue %}
+    func {{ case.name }}(
+                    {% for associatedValue in case.associatedValues %}
+                        {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
+        {{ name }}: {{ associatedValue.typeName }}{{ ", " if not forloop.last }}
+                    {% endfor %}
+    ) {
+                {% else %}
+    func {{ case.name }}() {
+                {% endif %}
+        fatalError("{{ case.name }} not implemented - needs to be overriden!")
+    }
+            {% endfor %}
+        {% else %}
+        // ⚠️ Found more than one type matching '{{ event}}}'
+        {% endif %}
+    {% endfor %}
+        
+    // MARK: Lifecycle
     
     func start() {}
     func stop() {}
-    
-                    {% for case in eventEnum.cases %}
-                        {% if case.hasAssociatedValue %}
-    func {{ case.name }}(
-                            {% for associatedValue in case.associatedValues %}
-                                {% set name %}{% call associatedValueName associatedValue forloop.counter %}{% endset %}
-        {{ name }}: {{ associatedValue.typeName }}{{ ", " if not forloop.last }}
-                            {% endfor %}
-    ) {
-                        {% else %}
-    func {{ case.name }}() {
-                        {% endif %}
-        fatalError("{{ case.name }} not implemented - needs to be overriden!")
-    }
-                    {% endfor %}
-                    
-                    {% break %}
-                {% endfor %}
-            {% endif %}
-    {% endfor %}
 }
 
-    {% endif %}
-  {% endfor %}
+        {% endif %}
+    {% endfor %}
 {% endfor %}
 
 /*

--- a/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Annotations.stencil
+++ b/Binaries/Sourcery.artifactbundle/sourcery-2.1.7/Templates/Annotations.stencil
@@ -15,12 +15,10 @@ import {{ import }}
 {% for type in types.structs %}
     {% for attribute, objects in type.attributes %}
         {% if attribute == "State" %}
-            {% set viewTypes %}{{ objects[0].description|replace:"@Event(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
-            {% for view in viewTypes|split: "," %}
+            {% set view %}{{ objects[0].description|replace:"@State(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
 extension {{ view }} {
     typealias State = {{ type.name }}
 }
-            {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
@@ -33,12 +31,10 @@ extension {{ view }} {
 {% for type in types.enums %}
     {% for attribute, objects in type.attributes %}
         {% if attribute == "Event" %}
-            {% set viewTypes %}{{ objects[0].description|replace:"@Event(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
-            {% for view in viewTypes|split: "," %}
+            {% set view %}{{ objects[0].description|replace:"@Event(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
 extension {{ view }} {
     typealias Event = {{ type.name }}
 }
-            {% endfor %}
         {% endif %}
     {% endfor %}
 {% endfor %}
@@ -126,25 +122,29 @@ enum OptionalUpdate<T> {
 }
 
 {% for type in types.all %}
-  {% for comment in type.documentation %}
+  {% for attribute, objects in type.attributes %}
     {% if attribute == "Loop" %}
-        {% set parameters %}{{ objects[0].description|replace:"@Loop(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
-        // TODO: get the state and event type
-        {% set event %}{{ parameters|replace:" ",""|split: ","[0] }}{% endset %}
-        {% set state %}{{ parameters|replace:" ",""|split: ","[1] }}{% endset %}
+        {% set parametersString %}{{ objects[0].description|replace:"@Loop(",""|replace:")",""|replace:".self",""|replace:" ","" }}{% endset %}
+        {% set parameters %}{{ parametersString|replace:" ","" }}{% endset %}
         
 import SwiftUDF
 import SwiftEvolution
 import Combine
         {% call includeImports type %}
-        
+
 class {{ type.name }}BaseGenerated: ViewProvider {
     let state: CurrentValuePublisher<State>
     private let mutableState: MutableState<State>
-    
-    typealias Event = {{ event }}
-    typealias State = {{ state }}
-    
+
+    {% for parameter in parameters|split: "," %}
+        {% if forloop.counter0 == 0 %}
+    typealias Event = {{ parameter|replace:"in:","" }}
+        {% endif %}
+        {% if forloop.counter0 == 1 %}
+    typealias State = {{ parameter|replace:"out:","" }}
+        {% endif %}
+    {% endfor %}
+
     // TODO: Default init for State thtat implements 'Initialable'
     init(initial: State) {
         mutableState = MutableState(initial)
@@ -152,12 +152,16 @@ class {{ type.name }}BaseGenerated: ViewProvider {
     }
     
     var subscriptions = [AnyCancellable]()
-    
+
     // MARK: State
-    
+
     var currentState: State { state.value }
-    
-    {% call propertyUpdates state %}
+
+    {% for parameter in parameters|split: "," %}
+        {% if forloop.counter0 == 1 %}
+    {% call propertyUpdates parameter|replace:"out:","" %}
+        {% endif %}
+    {% endfor %}
     
     func update(_ newState: State) {
         mutableState.send(newState)
@@ -170,10 +174,10 @@ class {{ type.name }}BaseGenerated: ViewProvider {
     func update(_ update: (MutableState<State>) -> Void) {
         update(mutableState)
     }
-    
+
     // MARK: Event
-    
-    {% for eventEnum in types.enums where eventEnum.name == event %}
+
+    {% for eventEnum in types.enums where parameters|contains:eventEnum.name %} // TODO: an exact event name match would be better...
         {% if forloop.counter == 1 %}
     func handle(_ event: Event) {
         {{ "switch event {" if eventEnum.cases.count > 0 }}
@@ -215,9 +219,9 @@ class {{ type.name }}BaseGenerated: ViewProvider {
         // ⚠️ Found more than one type matching '{{ event}}}'
         {% endif %}
     {% endfor %}
-        
+
     // MARK: Lifecycle
-    
+
     func start() {}
     func stop() {}
 }

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B93F2C952DAA36BF002EBDC9 /* SwiftUDF in Frameworks */ = {isa = PBXBuildFile; productRef = B93F2C942DAA36BF002EBDC9 /* SwiftUDF */; };
 		B9917FA92C1642E100F10DB0 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9917FA82C1642E100F10DB0 /* DemoApp.swift */; };
 		B9917FAD2C1642E400F10DB0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9917FAC2C1642E400F10DB0 /* Assets.xcassets */; };
 		B9917FB12C1642E400F10DB0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9917FB02C1642E400F10DB0 /* Preview Assets.xcassets */; };
@@ -45,6 +46,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B93F2C952DAA36BF002EBDC9 /* SwiftUDF in Frameworks */,
 				B9917FD52C16438B00F10DB0 /* SwiftUDF in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -129,11 +131,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				B9BDAC6E2C194E0C00EC659E /* PBXTargetDependency */,
+				B93F2C972DAA36C8002EBDC9 /* PBXTargetDependency */,
 			);
 			name = Demo;
 			packageProductDependencies = (
 				B9917FD42C16438B00F10DB0 /* SwiftUDF */,
+				B93F2C942DAA36BF002EBDC9 /* SwiftUDF */,
 			);
 			productName = Demo;
 			productReference = B9917FA52C1642E100F10DB0 /* Demo.app */;
@@ -186,7 +189,7 @@
 			);
 			mainGroup = B9917F9C2C1642E100F10DB0;
 			packageReferences = (
-				B9BDAC6A2C194DFD00EC659E /* XCRemoteSwiftPackageReference "SwiftUDF" */,
+				B93F2C932DAA36BF002EBDC9 /* XCLocalSwiftPackageReference "../../swift-unidirectional-data-flow" */,
 			);
 			productRefGroup = B9917FA62C1642E100F10DB0 /* Products */;
 			projectDirPath = "";
@@ -240,14 +243,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B93F2C972DAA36C8002EBDC9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B93F2C962DAA36C8002EBDC9 /* SwiftUDFCodeGeneratorPlugin */;
+		};
 		B9917FB82C1642E400F10DB0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B9917FA42C1642E100F10DB0 /* Demo */;
 			targetProxy = B9917FB72C1642E400F10DB0 /* PBXContainerItemProxy */;
-		};
-		B9BDAC6E2C194E0C00EC659E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = B9BDAC6D2C194E0C00EC659E /* SwiftUDFCodeGeneratorPlugin */;
 		};
 /* End PBXTargetDependency section */
 
@@ -520,26 +523,26 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		B9BDAC6A2C194DFD00EC659E /* XCRemoteSwiftPackageReference "SwiftUDF" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/davidscheutz/SwiftUDF.git";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		B93F2C932DAA36BF002EBDC9 /* XCLocalSwiftPackageReference "../../swift-unidirectional-data-flow" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../swift-unidirectional-data-flow";
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B9917FD42C16438B00F10DB0 /* SwiftUDF */ = {
+		B93F2C942DAA36BF002EBDC9 /* SwiftUDF */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SwiftUDF;
 		};
-		B9BDAC6D2C194E0C00EC659E /* SwiftUDFCodeGeneratorPlugin */ = {
+		B93F2C962DAA36C8002EBDC9 /* SwiftUDFCodeGeneratorPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B9BDAC6A2C194DFD00EC659E /* XCRemoteSwiftPackageReference "SwiftUDF" */;
+			package = B93F2C932DAA36BF002EBDC9 /* XCLocalSwiftPackageReference "../../swift-unidirectional-data-flow" */;
 			productName = "plugin:SwiftUDFCodeGeneratorPlugin";
+		};
+		B9917FD42C16438B00F10DB0 /* SwiftUDF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftUDF;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,22 +1,22 @@
 {
-  "originHash" : "787189544fbcb5e6c1cc135d509def186f493048c8e1d70576f703f1ce144908",
+  "originHash" : "532d6a40db1cc6d6e8cb99955c9a86f34b595cf3c615152af6a07168aea4f747",
   "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
     {
       "identity" : "swiftevolution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/davidscheutz/SwiftEvolution.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "0fc4402897ac4b06fc410754ce7f7f245f19cce2"
-      }
-    },
-    {
-      "identity" : "swiftudf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/davidscheutz/SwiftUDF.git",
-      "state" : {
-        "branch" : "master",
-        "revision" : "02ed242b8632f5010b446d1e14863552b176fc96"
+        "revision" : "0fc4402897ac4b06fc410754ce7f7f245f19cce2",
+        "version" : "0.0.1"
       }
     }
   ],

--- a/Demo/Demo/Counter/CounterLoop.swift
+++ b/Demo/Demo/Counter/CounterLoop.swift
@@ -1,7 +1,8 @@
 import Foundation
+import SwiftUDF
 
-/// @Loop(CounterState, CounterEvent)
-final class CounterLoop: GeneratedBaseCounterLoop {
+@Loop(in: CounterEvent.self, out: CounterState.self)
+final class CounterLoop: CounterLoopBaseGenerated {
     init() {
         super.init(initial: .init(increment: .byOne, count: 0, error: nil))
     }

--- a/Demo/Demo/Counter/CounterLoop.swift
+++ b/Demo/Demo/Counter/CounterLoop.swift
@@ -34,7 +34,7 @@ final class CounterLoop: CounterLoopBaseGenerated {
     
     private func resetErrorDelayed() {
         Task {
-            try await Task.sleep(nanoseconds: 2 * 1_000_000_000) // 2 seconds
+            try await Task.sleep(for: .seconds(2))
             updateError(nil)
         }
     }

--- a/Demo/Demo/Counter/CounterState.swift
+++ b/Demo/Demo/Counter/CounterState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUDF
 
 enum Increment: Int, CaseIterable, Identifiable {
     case byOne = 1
@@ -9,6 +10,7 @@ enum Increment: Int, CaseIterable, Identifiable {
     var display: String { "\(rawValue)" }
 }
 
+@State(CounterView.self)
 struct CounterState {
     let increment: Increment
     let count: Int
@@ -19,6 +21,7 @@ struct CounterState {
     }
 }
 
+@Event(CounterView.self)
 enum CounterEvent {
     case incrementSelected(_ increment: Increment)
     case increase

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
+    {
       "identity" : "swiftevolution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/davidscheutz/SwiftEvolution.git",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .target(
             name: "SwiftUDF",
             dependencies: [
-                .product(name: "SwiftEvolution", package: "SwiftEvolution")
+                .product(name: "SwiftEvolution", package: "SwiftEvolution"),
+                .byNameItem(name: "SwiftUDFMacroPlugin", condition: nil)
             ]
         ),
         .macro(

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "SwiftUDF",
@@ -11,13 +12,21 @@ let package = Package(
         .plugin(name: "SwiftUDFCodeGeneratorPlugin", targets: ["SwiftUDFCodeGeneratorPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/davidscheutz/SwiftEvolution.git", from: "0.0.1")
+        .package(url: "https://github.com/davidscheutz/SwiftEvolution.git", from: "0.0.1"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
         .target(
             name: "SwiftUDF",
             dependencies: [
                 .product(name: "SwiftEvolution", package: "SwiftEvolution")
+            ]
+        ),
+        .macro(
+            name: "SwiftUDFMacroPlugin",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
             ]
         ),
         .plugin(

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ protocol ViewProvider {
 Continuing with our counter app example, a basic `Loop` implementation could look as followed:
 
 ```swift
-/// @Loop(CounterState, CounterEvent)
-final class CounterLoop: GeneratedBaseCounterLoop {
+@Loop(in: CounterEvent.self, out: CounterState.self)
+final class CounterLoop: CounterLoopBaseGenerated {
     override func increase() {
         updateCount(count + 1)
     }
@@ -102,7 +102,7 @@ final class CounterLoop: GeneratedBaseCounterLoop {
 }
 ```
 
-Using the `@Loop(State, Event)` annotation, `SwiftUDF` will generate a "BaseLoop" `class` including the following functionalities:
+Using the `@Loop(Event, State)` annotation, `SwiftUDF` will generate a "BaseLoop" `class` including the following functionalities:
 - first level read-only variables for each field of the `State` each field of the `State`
 - update functions for each field of the `State`
 - a dedicated function for every user input aka every case of the `Event` enum

--- a/Sources/SwiftUDF/BindableView+Create.swift
+++ b/Sources/SwiftUDF/BindableView+Create.swift
@@ -15,8 +15,8 @@ extension BindableView {
 fileprivate struct BindableContainerView<Provider: ViewProvider, ChildView: BindableView & View>: View
     where ChildView.State == Provider.State, ChildView.Event == Provider.Event {
     
-    @State private var state: ChildView.State
-    @State private var provider: Provider
+    @SwiftUI.State private var state: ChildView.State
+    @SwiftUI.State private var provider: Provider
     
     private let viewBuilder: (ChildView.State, @escaping (ChildView.Event) -> Void) -> ChildView
     

--- a/Sources/SwiftUDF/Macros.swift
+++ b/Sources/SwiftUDF/Macros.swift
@@ -1,0 +1,37 @@
+/// Declares an annotation that can be used to generate a Loop.
+///
+/// A `@Loop` generates the base class for the provided state and event type.
+///
+///
+/// - Parameters:
+///   - event: Specifies the type of events that the loop will process.
+///   - state: Specifies the type of the state the loop will mutate.
+@attached(peer, names: named(Singleton))
+public macro Loop(
+    in event: Any.Type,
+    out state: Any.Type
+) = #externalMacro(module: "SwiftUDFMacro", type: "LoopMacro")
+
+/// Declares an annotation that can be used to specify a state.
+///
+/// A `@State` links the type to the provided views.
+///
+///
+/// - Parameters:
+///   - views: Specifies the types that the state will be linked to.
+@attached(peer, names: named(Singleton))
+public macro State(
+    _ views: Any.Type...,
+) = #externalMacro(module: "SwiftUDFMacro", type: "StateMacro")
+
+/// Declares an annotation that can be used to specify an event.
+///
+/// A `@Event` links the type to the provided views.
+///
+///
+/// - Parameters:
+///   - views: Specifies the types that the event will be linked to.
+@attached(peer, names: named(Singleton))
+public macro State(
+    _ views: Any.Type...,
+) = #externalMacro(module: "SwiftUDFMacro", type: "EventMacro")

--- a/Sources/SwiftUDF/Macros.swift
+++ b/Sources/SwiftUDF/Macros.swift
@@ -10,7 +10,7 @@
 public macro Loop(
     in event: Any.Type,
     out state: Any.Type
-) = #externalMacro(module: "SwiftUDFMacro", type: "LoopMacro")
+) = #externalMacro(module: "SwiftUDFMacroPlugin", type: "LoopMacro")
 
 /// Declares an annotation that can be used to specify a state.
 ///
@@ -18,11 +18,9 @@ public macro Loop(
 ///
 ///
 /// - Parameters:
-///   - views: Specifies the types that the state will be linked to.
+///   - view: Specifies the type that the state will be linked to.
 @attached(peer, names: named(Singleton))
-public macro State(
-    _ views: Any.Type...,
-) = #externalMacro(module: "SwiftUDFMacro", type: "StateMacro")
+public macro State(_ view: Any.Type) = #externalMacro(module: "SwiftUDFMacroPlugin", type: "StateMacro")
 
 /// Declares an annotation that can be used to specify an event.
 ///
@@ -30,8 +28,6 @@ public macro State(
 ///
 ///
 /// - Parameters:
-///   - views: Specifies the types that the event will be linked to.
+///   - view: Specifies the type that the event will be linked to.
 @attached(peer, names: named(Singleton))
-public macro State(
-    _ views: Any.Type...,
-) = #externalMacro(module: "SwiftUDFMacro", type: "EventMacro")
+public macro Event(_ view: Any.Type) = #externalMacro(module: "SwiftUDFMacroPlugin", type: "EventMacro")

--- a/Sources/SwiftUDFMacroPlugin/EventMacro.swift
+++ b/Sources/SwiftUDFMacroPlugin/EventMacro.swift
@@ -1,0 +1,18 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import Foundation
+
+public struct EventMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        /*
+         Code generation is still done using Sourcery.
+         Plan is to migrate functionality over to Swift macros over time.
+         */
+        return []
+    }
+}

--- a/Sources/SwiftUDFMacroPlugin/LoopMacro.swift
+++ b/Sources/SwiftUDFMacroPlugin/LoopMacro.swift
@@ -1,0 +1,20 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import Foundation
+
+// this should generate an extension confirming to the base type
+// extension LoginLoop: ListLoopBaseGenerated {}
+public struct LoopMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        /*
+         Code generation is still done using Sourcery.
+         Plan is to migrate functionality over to Swift macros over time.
+         */
+        return []
+    }
+}

--- a/Sources/SwiftUDFMacroPlugin/LoopMacro.swift
+++ b/Sources/SwiftUDFMacroPlugin/LoopMacro.swift
@@ -3,8 +3,6 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import Foundation
 
-// this should generate an extension confirming to the base type
-// extension LoginLoop: ListLoopBaseGenerated {}
 public struct LoopMacro: PeerMacro {
     public static func expansion(
         of node: AttributeSyntax,

--- a/Sources/SwiftUDFMacroPlugin/StateMacro.swift
+++ b/Sources/SwiftUDFMacroPlugin/StateMacro.swift
@@ -1,0 +1,18 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import Foundation
+
+public struct StateMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        /*
+         Code generation is still done using Sourcery.
+         Plan is to migrate functionality over to Swift macros over time.
+         */
+        return []
+    }
+}

--- a/Sources/SwiftUDFMacroPlugin/SwiftUDFMacroPlugin.swift
+++ b/Sources/SwiftUDFMacroPlugin/SwiftUDFMacroPlugin.swift
@@ -1,0 +1,12 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+import Foundation
+
+@main
+struct SwiftUDFMacroPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        LoopMacro.self,
+        StateMacro.self,
+        EventMacro.self
+    ]
+}


### PR DESCRIPTION
Replace legacy comment based annotations with Swift Macros, making the compile safe!

```swift
@Loop(in: EventType, out: StateType)
@State(ViewType)
@Event(ViewType)
```

Demo project and readme was updated accordingly.